### PR TITLE
Add support for enterprise CircleCI instances

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -256,3 +256,18 @@ Clear build cache
 
    # Clear build cache
    client.cache.clear(username='<username>', project='<project_name>')
+
+
+Use a custom CircleCI endpoint
+------------------------------
+
+.. code:: python
+
+   import os
+   from circleclient import circleclient
+
+   token = os.environ['API_TOKEN']
+   client = circleclient.CircleClient(api_token=token, endpoint='https://cci.example.com/api/v1')
+
+   # Use client as normal
+   client.user.info()

--- a/circleclient/circleclient.py
+++ b/circleclient/circleclient.py
@@ -13,8 +13,9 @@ class CircleClient(object):
     Attributes:
         api_token: CircleCI API token for the client.
     """
-    def __init__(self, api_token=None):
+    def __init__(self, api_token=None, endpoint=None):
         self.api_token = api_token
+        self.endpoint = 'https://circleci.com/api/v1' if endpoint is None else endpoint
         self.headers = self.make_headers()
         self.user = User(self)
         self.projects = Projects(self)
@@ -31,8 +32,7 @@ class CircleClient(object):
                 'Accept': 'application/json'}
 
     def make_url(self, path):
-        endpoint = 'https://circleci.com/api/v1'
-        return endpoint + path
+        return self.endpoint + path
 
     def client_get(self, url, **kwargs):
         """Send GET request with given url."""

--- a/docs/usage.rst
+++ b/docs/usage.rst
@@ -177,3 +177,18 @@ Clear build cache
 
    # Clear build cache
    client.cache.clear(username='<username>', project='<project_name>')
+
+
+Use a custom CircleCI endpoint
+------------------------------
+
+.. code:: python
+
+   import os
+   from circleclient import circleclient
+
+   token = os.environ['API_TOKEN']
+   client = circleclient.CircleClient(api_token=token, endpoint='https://cci.example.com/api/v1')
+
+   # Use client as normal
+   client.user.info()


### PR DESCRIPTION
If you have an enterprise instance of CircleCI, the url through which you access the api is different than that of the public instance. This commit adds support for alternate CCI endpoints, but still provides a sensible fallback.

The current api remains the same for accessing public CCI:

``` python
client = circleclient.CircleClient(token)
```

But there is now an additional `endpoint` keyword you can pass that specifies a custom endpoint:

``` python
client = circleclient.CircleClient(token, endpoint='https://cci.example.com/api/v1')
```

If you so wished, you could _also_ specify the public CCI endpoint this way:

``` python
client = circleclient.CircleClient(token, endpoint='https://circleci.com/api/v1')
```
