### PR TITLE
Switched broken pypip.in badges to shields.io

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -6,11 +6,11 @@ circleclient
     :target: https://travis-ci.org/qba73/circleclient
     :alt: Travis CI Build Status
 
-.. image:: https://pypip.in/v/circleclient/badge.png
+.. image:: https://img.shields.io/pypi/v/circleclient.svg
     :target: https://pypi.python.org/pypi/circleclient
     :alt: Latest Version
 
-.. image:: https://pypip.in/license/circleclient/badge.png
+.. image:: https://img.shields.io/pypi/l/circleclient.svg
     :target: https://pypi.python.org/pypi/circleclient/
     :alt: License
 


### PR DESCRIPTION
Hello, this is an auto-generated Pull Request. ([Feedback?](mailto:repobot@movermeyer.com?subject=pypip.in%20Badge%20Bot%20Feedback%3A%20circleclient))

Some time ago, [pypip.in](https://web.archive.org/web/20150318013508/https://pypip.in/) shut down. This broke the badges for a bunch of repositories, including `circleclient`. Thankfully, an equivalent service is run by [shields.io](https://shields.io). This pull request changes the badges to use shields.io instead.